### PR TITLE
R9M Flex power option menu for colorlcd

### DIFF
--- a/radio/src/gui/colorlcd/model_setup.cpp
+++ b/radio/src/gui/colorlcd/model_setup.cpp
@@ -1264,6 +1264,12 @@ class ModuleWindow : public FormGroup {
                    SET_DEFAULT(g_model.moduleData[moduleIdx].pxx.power));
       }
      
+      if (isModuleR9M_EUPLUS(moduleIdx) || isModuleR9M_AU_PLUS(moduleIdx)) {
+        new StaticText(this, grid.getLabelSlot(true), STR_RF_POWER, 0, COLOR_THEME_PRIMARY1);
+        new Choice(this, grid.getFieldSlot(), STR_R9M_FCC_POWER_VALUES, 0, R9M_FCC_POWER_MAX,
+                   GET_SET_DEFAULT(g_model.moduleData[moduleIdx].pxx.power));
+      }
+      
 #if defined(PXX2)
       // Receivers
       if (isModuleRFAccess(moduleIdx)) {


### PR DESCRIPTION
Adds power selection menu for R9M Flex  (ACCST, pre 2019) on colorlcd radios. Tested working on a tx16s.
https://github.com/EdgeTX/edgetx/issues/1187

<!-- 
Please note that pull requests are NOT an appropriate way to
ask questions or for support, and will be closed. 

For feature requests or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.

Feel free to delete any of the below which does not apply.
-->

Fixes #

Summary of changes:
